### PR TITLE
Make all mods ranked on the client (except for the exceptions)

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 0.9;
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Mania.Mods
             typeof(ManiaModFadeIn)
         }).ToArray();
 
-        public override bool Ranked => true;
 
         public override bool ValidForFreestyleAsRequiredMod => false;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -17,5 +17,6 @@ namespace osu.Game.Rulesets.Mania.Mods
             ExtendedMinValue = -15,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
         };
+        public override bool Ranked => (OverallDifficulty.Value ?? 8f) >= 6f
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDifficultyAdjust.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             ExtendedMinValue = -15,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
         };
-        public override bool Ranked => (OverallDifficulty.Value ?? 8f) >= 6f
+
+        public override bool Ranked => (OverallDifficulty.Value ?? 8f) >= 6f;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -11,7 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModHardRock : ModHardRock, IApplicableToHitObject
     {
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => false;
 
         public const double HIT_WINDOW_DIFFICULTY_MULTIPLIER = 1.4;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override IconUsage? Icon => OsuIcon.ModInvert;
 
         public override ModType Type => ModType.Conversion;
+        public override bool Ranked => false;
 
         public override Type[] IncompatibleMods => new[] { typeof(ManiaModHoldOff) };
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -14,6 +14,5 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "1K";
         public override IconUsage? Icon => OsuIcon.ModOneKey;
         public override LocalisableString Description => @"Play with one key.";
-        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -14,6 +14,5 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "10K";
         public override IconUsage? Icon => OsuIcon.ModTenKeys;
         public override LocalisableString Description => @"Play with ten keys.";
-        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -14,6 +14,5 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "2K";
         public override IconUsage? Icon => OsuIcon.ModTwoKeys;
         public override LocalisableString Description => @"Play with two keys.";
-        public override bool Ranked => false;
-    }
+            }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -14,6 +14,5 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "3K";
         public override IconUsage? Icon => OsuIcon.ModThreeKeys;
         public override LocalisableString Description => @"Play with three keys.";
-        public override bool Ranked => false;
-    }
+            }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModMirror : ModMirror, IApplicableToBeatmap
     {
         public override LocalisableString Description => "Notes are flipped horizontally.";
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"Don't use the same key twice in a row!";
         public override IconUsage? Icon => OsuIcon.ModAlternate;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModSingleTap) }).ToArray();
-        public override bool Ranked => true;
 
         protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction != action;
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
-        public override bool Ranked => true;
 
         private DrawableOsuBlinds blinds = null!;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBloom.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "The cursor blooms into.. a larger cursor!";
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => false;
         protected const float MIN_SIZE = 1;
         protected const float TRANSITION_DURATION = 100;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight), typeof(OsuModNoScope), typeof(ModTouchDevice) };

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
         public override double ScoreMultiplier => 0.5;
+        public override bool Ranked => false;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel), typeof(OsuModBubbles), typeof(OsuModDepth) };
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override IconUsage? Icon => OsuIcon.ModSingleTap;
         public override LocalisableString Description => @"You must only use one key!";
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAlternate) }).ToArray();
-        public override bool Ranked => true;
 
         protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction == null || LastAcceptedAction == action;
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"Spinners will be automatically completed.";
         public override double ScoreMultiplier => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot), typeof(OsuModTargetPractice) };
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         public void ApplyToDrawableHitObject(DrawableHitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModTouchDevice : ModTouchDevice
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModBloom) }).ToArray();
-        public override bool Ranked => UsesDefaultConfiguration;
+
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Put your faith in the approach circles...";
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
 
         public override Type[] IncompatibleMods => new[] { typeof(IHidesApproachCircles), typeof(OsuModDepth) };
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSingleTap.cs
@@ -29,8 +29,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override IconUsage? Icon => OsuIcon.ModSingleTap;
         public override LocalisableString Description => @"One key for dons, one key for kats.";
 
-        public override bool Ranked => true;
-        public override double ScoreMultiplier => 1.0;
+                public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(TaikoModCinema) };
         public override ModType Type => ModType.Conversion;
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -22,7 +22,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModRandom)).ToArray();
-        public override bool Ranked => true;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Mods
         public virtual bool RequiresConfiguration => false;
 
         [JsonIgnore]
-        public virtual bool Ranked => false;
+        public virtual bool Ranked => true;
 
         /// <summary>
         /// The mods this mod cannot be enabled with.

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool RequiresConfiguration => false;
 
-        public override bool Ranked => true;
 
         public override IEnumerable<(LocalisableString setting, LocalisableString value)> SettingDescription
         {

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.Fun;
 
         public override double ScoreMultiplier => 0.5;
+        public override bool Ranked => false;
 
         public sealed override bool ValidForMultiplayer => false;
         public sealed override bool ValidForMultiplayerAsFreeMod => false;

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDaycore;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Whoaaaaa...";
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Zoooooooooom...";
-        public override bool Ranked => true;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyReduction;
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
-        public override bool Ranked => UsesDefaultConfiguration;
+
         public override bool ValidForFreestyleAsRequiredMod => true;
 
         public const float ADJUST_RATIO = 0.5f;

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHalfTime;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Less zoom...";
-        public override bool Ranked => SpeedChange.IsDefault;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Everything just got a bit harder...";
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust) };
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => true;
         public override bool ValidForFreestyleAsRequiredMod => true;
 
         protected const float ADJUST_RATIO = 1.4f;

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -17,8 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Everything just got a bit harder...";
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust) };
-        public override bool Ranked => true;
-        public override bool ValidForFreestyleAsRequiredMod => true;
+                public override bool ValidForFreestyleAsRequiredMod => true;
 
         protected const float ADJUST_RATIO = 1.4f;
 

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "HD";
         public override IconUsage? Icon => OsuIcon.ModHidden;
         public override ModType Type => ModType.DifficultyIncrease;
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -26,8 +26,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
-        public override bool ValidForFreestyleAsRequiredMod => true;
+                public override bool ValidForFreestyleAsRequiredMod => true;
     }
 
     public abstract class ModMuted<TObject> : ModMuted, IApplicableToDrawableRuleset<TObject>, IApplicableToTrack, IApplicableToScoreProcessor

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNightcore;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Uguuuuuuuu...";
-        public override bool Ranked => UsesDefaultConfiguration;
+
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "You can't fail, no matter what.";
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
-        public override bool Ranked => UsesDefaultConfiguration;
+
         public override bool ValidForFreestyleAsRequiredMod => true;
 
         private readonly Bindable<bool> showHealthBar = new Bindable<bool>();

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.Fun;
         public override IconUsage? Icon => OsuIcon.ModNoScope;
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
 
         /// <summary>
         /// Slightly higher than the cutoff for <see cref="Drawable.IsPresent"/>.

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -19,8 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override double ScoreMultiplier => 1;
         public override LocalisableString Description => "SS or quit.";
-        public override bool Ranked => true;
-        public override bool ValidForFreestyleAsRequiredMod => true;
+                public override bool ValidForFreestyleAsRequiredMod => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModSuddenDeath), typeof(ModAccuracyChallenge) }).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -19,8 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
-        public override bool ValidForFreestyleAsRequiredMod => true;
+                public override bool ValidForFreestyleAsRequiredMod => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).ToArray();
 


### PR DESCRIPTION
this doesnt change anything server wide just visual stuff on the client

keeps bloom, invert, adaptive speed, magnetised, mania difficulty adjust with od below 6, ranks every other mod

