### PR TITLE
Adding AMD Anti-Lag 2 support for all RDNA cards. 

### DIFF
--- a/osu.Desktop/LowLatency/AMD/ffx_antilag2_dx11.h
+++ b/osu.Desktop/LowLatency/AMD/ffx_antilag2_dx11.h
@@ -2,23 +2,92 @@
 // See the LICENCE file in the repository root for full licence text.
 
 // AMD Anti-Lag 2 SDK DirectX 11 Header
-// Based on GPUOpen Anti-Lag 2 SDK documentation
+// Based on GPUOpen Anti-Lag 2 SDK v2.0
+// This header provides the modern FidelityFX Anti-Lag 2 API using AMD Driver Extension
 
 #pragma once
 
 #include <dxgi.h>
 #include <d3d11.h>
+#include <windows.h>
 
 #ifdef __cplusplus
+namespace AMD {
+namespace AntiLag2DX11 {
+
+    struct Context;
+
+    // Initialize function - call this once before the Update function.
+    // context - Declare a persistent Context variable in your game code. Ensure the contents are zero'ed, and pass the address in to initialize it.
+    //           Be sure to use the *same* context object everywhere when calling the Anti-Lag 2.0 SDK functions.
+    // A return value of S_OK indicates that Anti-Lag 2.0 is available on the system.
+    HRESULT Initialize( Context* context );
+
+    // DeInitialize function - call this on game exit.
+    // context - address of the game's context object.
+    // The return value is the reference count of the internal API. It should be 0.
+    ULONG DeInitialize( Context* context );
+
+    // Update function - call this just before the input to the game is polled.
+    // context - address of the game's context object.
+    // enable - enables or disables Anti-Lag 2.0.
+    // maxFPS - sets a framerate limit. Zero will disable the limiter.
+    HRESULT Update( Context* context, bool enable, unsigned int maxFPS );
+
+    // Forward declaration of the Anti-Lag 2.0 interface into the DX11 driver
+    class IAmdDxExtInterface
+    {
+    public:
+        virtual unsigned int AddRef() = 0;
+        virtual unsigned int Release() = 0;
+
+    protected:
+        IAmdDxExtInterface() {}
+        virtual ~IAmdDxExtInterface() = 0 {}
+    };
+
+    // Structure version 1 for Anti-Lag 2.0:
+    struct APIData_v1
+    {
+        unsigned int    uiSize;
+        unsigned int    uiVersion;
+        unsigned int    eMode;
+        const char*     sControlStr;
+        unsigned int    uiControlStrLength;
+        unsigned int    maxFPS;
+    };
+
+    // Forward declaration of the Anti-Lag interface into the DX11 driver
+    struct IAmdDxExtAntiLagApi : public IAmdDxExtInterface
+    {
+    public:
+        virtual HRESULT UpdateAntiLagStateDx11( APIData_v1* pApiCallbackData ) = 0;
+    };
+
+    // Context structure for the SDK. Declare a persistent object of this type *once* in your game code.
+    // Ensure the contents are initialized to zero before calling Initialize() but do not modify these members directly after that.
+    struct Context
+    {
+        IAmdDxExtAntiLagApi*  m_pAntiLagAPI = nullptr;
+        bool                  m_enabled = false;
+        unsigned int          m_maxFPS = 0;
+    };
+
+} // namespace AntiLag2DX11
+} // namespace AMD
+
 extern "C" {
 #endif
+
+    // Legacy C-compatible API (for backward compatibility with older drivers)
+    // These functions use the internal amd_antilag_dx11.dll which works on RDNA 1-3 (RX 5000-7000 series)
+    // For RDNA 4 (RX 9000 series) support, use the C++ namespace API above instead.
 
     typedef struct AntiLag2DX11Context
     {
         void* reserved[8];
     } AntiLag2DX11Context;
 
-    // Anti-Lag 2 modes
     typedef enum AntiLag2Mode
     {
         ANTI_LAG_2_MODE_OFF = 0,
@@ -26,7 +95,6 @@ extern "C" {
         ANTI_LAG_2_MODE_BOOST = 2
     } AntiLag2Mode;
 
-    // Anti-Lag 2 return codes
     typedef enum AntiLag2Result
     {
         ANTI_LAG_2_RESULT_OK = 0,
@@ -36,22 +104,18 @@ extern "C" {
         ANTI_LAG_2_RESULT_NOT_INITIALIZED = -4
     } AntiLag2Result;
 
-    // Initialize Anti-Lag 2 for DirectX 11
-    // Returns ANTI_LAG_2_RESULT_OK on success
+    // Initialize Anti-Lag 2 for DirectX 11 (Legacy)
     AntiLag2Result AmdAntiLag2Dx11Initialize(
         AntiLag2DX11Context* context,
         ID3D11Device* device);
 
-    // Update Anti-Lag 2 state
-    // Call this just before polling input
-    // enable: true to enable, false to disable
-    // maxFps: 0 to disable frame rate limiting, otherwise target FPS
+    // Update Anti-Lag 2 state (Legacy)
     AntiLag2Result AmdAntiLag2Dx11Update(
         AntiLag2DX11Context* context,
         bool enable,
         unsigned int maxFps);
 
-    // Deinitialize Anti-Lag 2
+    // Deinitialize Anti-Lag 2 (Legacy)
     AntiLag2Result AmdAntiLag2Dx11DeInitialize(
         AntiLag2DX11Context* context);
 

--- a/osu.Desktop/LowLatency/AMDAntiLag2Direct3D11LowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/AMDAntiLag2Direct3D11LowLatencyProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -12,6 +12,7 @@ namespace osu.Desktop.LowLatency
 {
     /// <summary>
     /// Provider for AMD's Anti-Lag 2 low latency features.
+    /// Uses the AMD Driver Extension API (AmdDxExtCreate11) which works on all RDNA-based GPUs including RX 9000 series.
     /// </summary>
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SupportedOSPlatform("windows")]
@@ -20,9 +21,47 @@ namespace osu.Desktop.LowLatency
         public bool IsAvailable { get; private set; }
 
         private IntPtr _deviceHandle;
-        private AntiLag2DX11Context _context;
+        private IntPtr _amdDxExtInterface;
         private bool _initialized;
         private LatencyMode currentMode = LatencyMode.Off;
+
+        [ComImport]
+        [Guid("C4FE4B80-5EE9-4B4E-8BC2-5A9A7C85A07D")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAmdDxExtInterface
+        {
+            uint AddRef();
+            uint Release();
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct APIData_v1
+        {
+            public uint uiSize;
+            public uint uiVersion;
+            public uint eMode;
+            public IntPtr sControlStr;
+            public uint uiControlStrLength;
+            public uint maxFPS;
+        }
+
+        [Guid("7E4D8A8E-3B3C-4D4A-9C5A-2E8D9B7C5F3A")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IAmdDxExtAntiLagApi
+        {
+            uint AddRef();
+            uint Release();
+            int UpdateAntiLagStateDx11(IntPtr pApiCallbackData);
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate int AmdDxExtCreate11Delegate(IntPtr pDevice, ref IntPtr ppAntiLagApi);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate int AmdDxExtCreate11NullDelegate(ref IntPtr ppAntiLagApi);
+
+        private AmdDxExtCreate11Delegate? _amdDxExtCreate11;
+        private bool _useNewAPI;
 
         /// <summary>
         /// Initialize the AMD Anti-Lag 2 low latency provider with a native device handle.
@@ -38,37 +77,144 @@ namespace osu.Desktop.LowLatency
 
             try
             {
-                // Check if the AMD Anti-Lag 2 DLL is available before trying to initialize
-                IntPtr antiLagDll = loadLibrary("amd_antilag_dx11.dll");
-                if (antiLagDll == IntPtr.Zero)
+                if (!tryInitializeNewAPI())
                 {
-                    IsAvailable = false;
-                    Logger.Log("AMD Anti-Lag 2 DLL (amd_antilag_dx11.dll) not found. Please ensure AMD drivers with Anti-Lag 2 support are installed.");
-                    return;
+                    if (!tryInitializeOldAPI())
+                    {
+                        IsAvailable = false;
+                        return;
+                    }
                 }
-                freeLibrary(antiLagDll);
 
-                // Initialize Anti-Lag 2 context
-                var result = AmdAntiLag2Dx11Initialize(ref _context, _deviceHandle);
-
-                if (result == AntiLag2Result.ANTI_LAG_2_RESULT_OK)
-                {
-                    IsAvailable = true;
-                    _initialized = true;
-                    currentMode = LatencyMode.Off;
-                    Logger.Log("AMD Anti-Lag 2 initialized successfully.");
-                }
-                else
-                {
-                    IsAvailable = false;
-                    Logger.Log($"AMD Anti-Lag 2 initialization failed with result: {result}");
-                }
+                IsAvailable = true;
+                _initialized = true;
+                currentMode = LatencyMode.Off;
+                Logger.Log($"AMD Anti-Lag 2 initialized successfully using {(_useNewAPI ? "AMD Driver Extension API (RDNA 1-4)" : "Legacy DLL (RDNA 1-3)")}.");
             }
             catch (Exception ex)
             {
                 IsAvailable = false;
                 Logger.Error(ex, "Failed to initialize AMD Anti-Lag 2");
             }
+        }
+
+        private bool tryInitializeNewAPI()
+        {
+            IntPtr amdDxExt = GetModuleHandle("amdxx64.dll");
+            if (amdDxExt == IntPtr.Zero)
+            {
+                Logger.Log("AMD Driver Extension (amdxx64.dll) not found. Trying legacy API...");
+                return false;
+            }
+
+            IntPtr createFunc = GetProcAddress(amdDxExt, "AmdDxExtCreate11");
+            if (createFunc == IntPtr.Zero)
+            {
+                Logger.Log("AmdDxExtCreate11 export not found in amdxx64.dll. Trying legacy API...");
+                return false;
+            }
+
+            _amdDxExtCreate11 = Marshal.GetDelegateForFunctionPointer<AmdDxExtCreate11Delegate>(createFunc);
+
+            IntPtr interfacePtr = IntPtr.Zero;
+
+            // Set up the "magic" request identifier (from AMD SDK)
+            long magicValue = 0xbf380ebc5ab4d0a6;
+            interfacePtr = new IntPtr(magicValue);
+
+            int hr = _amdDxExtCreate11(_deviceHandle, ref interfacePtr);
+
+            if (hr != 0 || interfacePtr == IntPtr.Zero)
+            {
+                Logger.Log($"AmdDxExtCreate11 failed with HRESULT: {hr}. Trying legacy API...");
+                _amdDxExtCreate11 = null;
+                return false;
+            }
+
+            // Query for the Anti-Lag API interface
+            try
+            {
+                IAmdDxExtInterface? extInterface = Marshal.GetObjectForIUnknown(interfacePtr) as IAmdDxExtInterface;
+                if (extInterface == null)
+                {
+                    extInterface?.Release();
+                    Logger.Log("Failed to query Anti-Lag interface. Trying legacy API...");
+                    return false;
+                }
+
+                _amdDxExtInterface = interfacePtr;
+                _useNewAPI = true;
+
+                // Initialize with disabled state
+                IAmdDxExtAntiLagApi? antiLagApi = extInterface as IAmdDxExtAntiLagApi;
+                if (antiLagApi != null)
+                {
+                    APIData_v1 initData = new APIData_v1
+                    {
+                        uiSize = (uint)Marshal.SizeOf<APIData_v1>(),
+                        uiVersion = 1,
+                        eMode = 2,
+                        sControlStr = IntPtr.Zero,
+                        uiControlStrLength = 0,
+                        maxFPS = 0
+                    };
+
+                    IntPtr initDataPtr = Marshal.AllocHGlobal(Marshal.SizeOf<APIData_v1>());
+                    try
+                    {
+                        Marshal.StructureToPtr(initData, initDataPtr, false);
+                        antiLagApi.UpdateAntiLagStateDx11(initDataPtr);
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal(initDataPtr);
+                    }
+                }
+
+                extInterface.Release();
+                return true;
+            }
+            catch
+            {
+                if (interfacePtr != IntPtr.Zero)
+                {
+                    IAmdDxExtInterface? extInterface = Marshal.GetObjectForIUnknown(interfacePtr) as IAmdDxExtInterface;
+                    extInterface?.Release();
+                }
+                Logger.Log("Failed to initialize Anti-Lag via new API. Trying legacy API...");
+                return false;
+            }
+        }
+
+        private bool tryInitializeOldAPI()
+        {
+            IntPtr antiLagDll = GetModuleHandle("amd_antilag_dx11.dll");
+            if (antiLagDll == IntPtr.Zero)
+            {
+                Logger.Log("AMD Anti-Lag 2 DLL (amd_antilag_dx11.dll) not found. Please ensure AMD drivers with Anti-Lag 2 support are installed.");
+                return false;
+            }
+
+            IntPtr initFunc = GetProcAddress(antiLagDll, "AmdAntiLag2Dx11Initialize");
+            if (initFunc == IntPtr.Zero)
+            {
+                Logger.Log("AmdAntiLag2Dx11Initialize not found in amd_antilag_dx11.dll");
+                return false;
+            }
+
+            var initializeDelegate = Marshal.GetDelegateForFunctionPointer<OldInitializeDelegate>(initFunc);
+
+            var context = new OldAntiLag2Context();
+            var result = initializeDelegate(ref context, _deviceHandle);
+
+            if (result != OldAntiLag2Result.ANTI_LAG_2_RESULT_OK)
+            {
+                Logger.Log($"Legacy AMD Anti-Lag 2 initialization failed with result: {result}");
+                return false;
+            }
+
+            _useNewAPI = false;
+            return true;
         }
 
         /// <summary>
@@ -89,18 +235,76 @@ namespace osu.Desktop.LowLatency
                 currentMode = mode;
                 bool enable = mode != LatencyMode.Off;
 
-                // For AMD Anti-Lag 2, we use the Update function
-                // Call just before input polling (this will be handled by the framework)
-                var result = AmdAntiLag2Dx11Update(ref _context, enable, 0); // 0 = no frame rate limit
-
-                if (result != AntiLag2Result.ANTI_LAG_2_RESULT_OK)
-                    throw new InvalidOperationException($"Failed to set AMD Anti-Lag 2 mode: {result}");
+                if (_useNewAPI)
+                {
+                    updateNewAPI(enable, 0);
+                }
+                else
+                {
+                    updateOldAPI(enable, 0);
+                }
             }
             catch (Exception ex)
             {
                 Logger.Error(ex, "Failed to set AMD Anti-Lag 2 mode");
                 throw new InvalidOperationException($"Failed to set AMD Anti-Lag 2 mode: {ex.Message}");
             }
+        }
+
+        private void updateNewAPI(bool enable, uint maxFps)
+        {
+            if (_amdDxExtInterface == IntPtr.Zero)
+                return;
+
+            IAmdDxExtInterface? extInterface = Marshal.GetObjectForIUnknown(_amdDxExtInterface) as IAmdDxExtInterface;
+            IAmdDxExtAntiLagApi? antiLagApi = extInterface as IAmdDxExtAntiLagApi;
+
+            if (antiLagApi == null)
+                return;
+
+            APIData_v1 data = new APIData_v1
+            {
+                uiSize = (uint)Marshal.SizeOf<APIData_v1>(),
+                uiVersion = 1,
+                eMode = enable ? 1u : 2u,
+                maxFPS = maxFps
+            };
+
+            string controlStr = "delag_next_osd_supported_in_dxxp = 1";
+            data.sControlStr = Marshal.StringToHGlobalAnsi(controlStr);
+            data.uiControlStrLength = (uint)controlStr.Length;
+
+            IntPtr dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf<APIData_v1>());
+            try
+            {
+                Marshal.StructureToPtr(data, dataPtr, false);
+                antiLagApi.UpdateAntiLagStateDx11(dataPtr);
+                antiLagApi.UpdateAntiLagStateDx11(IntPtr.Zero);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(data.sControlStr);
+                Marshal.FreeHGlobal(dataPtr);
+            }
+        }
+
+        private void updateOldAPI(bool enable, uint maxFps)
+        {
+            IntPtr antiLagDll = GetModuleHandle("amd_antilag_dx11.dll");
+            if (antiLagDll == IntPtr.Zero)
+                return;
+
+            IntPtr updateFunc = GetProcAddress(antiLagDll, "AmdAntiLag2Dx11Update");
+            if (updateFunc == IntPtr.Zero)
+                return;
+
+            var updateDelegate = Marshal.GetDelegateForFunctionPointer<OldUpdateDelegate>(updateFunc);
+
+            var context = new OldAntiLag2Context();
+            var result = updateDelegate(ref context, enable, maxFps);
+
+            if (result != OldAntiLag2Result.ANTI_LAG_2_RESULT_OK)
+                throw new InvalidOperationException($"Failed to set AMD Anti-Lag 2 mode: {result}");
         }
 
         /// <summary>
@@ -114,10 +318,6 @@ namespace osu.Desktop.LowLatency
         {
             if (!IsAvailable || !_initialized)
                 return;
-
-            // AMD Anti-Lag 2 doesn't use markers like NVIDIA Reflex
-            // The latency reduction is handled internally by the Update() call
-            // which should be called just before input polling
         }
 
         /// <summary>
@@ -128,40 +328,28 @@ namespace osu.Desktop.LowLatency
         {
             if (!IsAvailable || !_initialized)
                 return;
-
-            // AMD Anti-Lag 2 doesn't have a separate FrameSleep function
-            // The timing is managed internally by the Update() call
         }
 
         #region Native Methods
 
-        [DllImport("amd_antilag_dx11.dll", EntryPoint = "AmdAntiLag2Dx11Initialize")]
-        private static extern AntiLag2Result AmdAntiLag2Dx11Initialize(ref AntiLag2DX11Context context, IntPtr device);
+        [DllImport("kernel32.dll", EntryPoint = "GetModuleHandle")]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
 
-        [DllImport("amd_antilag_dx11.dll", EntryPoint = "AmdAntiLag2Dx11Update")]
-        private static extern AntiLag2Result AmdAntiLag2Dx11Update(ref AntiLag2DX11Context context, bool enable, uint maxFps);
-
-        [DllImport("amd_antilag_dx11.dll", EntryPoint = "AmdAntiLag2Dx11DeInitialize")]
-        private static extern AntiLag2Result AmdAntiLag2Dx11DeInitialize(ref AntiLag2DX11Context context);
-
-        [DllImport("kernel32.dll", EntryPoint = "LoadLibrary")]
-        private static extern IntPtr loadLibrary(string dllToLoad);
-
-        [DllImport("kernel32.dll", EntryPoint = "FreeLibrary")]
-        private static extern bool freeLibrary(IntPtr hModule);
+        [DllImport("kernel32.dll", EntryPoint = "GetProcAddress")]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
 
         #endregion
 
-        #region Native Structures
+        #region Legacy API Types
 
         [StructLayout(LayoutKind.Sequential)]
-        private struct AntiLag2DX11Context
+        private struct OldAntiLag2Context
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
             public IntPtr[] reserved;
         }
 
-        private enum AntiLag2Result
+        private enum OldAntiLag2Result
         {
             ANTI_LAG_2_RESULT_OK = 0,
             ANTI_LAG_2_RESULT_FAIL = -1,
@@ -169,6 +357,12 @@ namespace osu.Desktop.LowLatency
             ANTI_LAG_2_RESULT_INVALID_ARGUMENT = -3,
             ANTI_LAG_2_RESULT_NOT_INITIALIZED = -4
         }
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate OldAntiLag2Result OldInitializeDelegate(ref OldAntiLag2Context context, IntPtr device);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate OldAntiLag2Result OldUpdateDelegate(ref OldAntiLag2Context context, bool enable, uint maxFps);
 
         #endregion
     }

--- a/osu.Desktop/LowLatency/AMDAntiLag2Direct3D11LowLatencyProvider.cs
+++ b/osu.Desktop/LowLatency/AMDAntiLag2Direct3D11LowLatencyProvider.cs
@@ -119,8 +119,8 @@ namespace osu.Desktop.LowLatency
             IntPtr interfacePtr = IntPtr.Zero;
 
             // Set up the "magic" request identifier (from AMD SDK)
-            long magicValue = 0xbf380ebc5ab4d0a6;
-            interfacePtr = new IntPtr(magicValue);
+            ulong magicValue = 0xbf380ebc5ab4d0a6;
+            interfacePtr = new IntPtr((long)magicValue);
 
             int hr = _amdDxExtCreate11(_deviceHandle, ref interfacePtr);
 


### PR DESCRIPTION
The previous way was just searching for amd_antilag_dx11.dll the newer cards are using amdxx64.dll so with that pull request the game searches for RDNA 4 cards so if amdxx64.dll is available if not it searches for the old .dll amd_antilag_dx11.dll that way it should work with all RDNA cards.