### PR TITLE
flow aim pp rework

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 //this is for washing machines type streams 
                 if (isRelax)
                 {
-                    // Trigger threshold lowered to 1.2 used to be  (catches even medium-sized circular abuse)
+                    // Trigger threshold highened to 1.2 used to be 1.0  (catches even medium-sized circular abuse)
                     if (currVelocity > 1.2)
                     {
                         //The wider the curve is the harsher will be the  flow aim nerf, killing abuse maps 
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime),
                     Math.Abs(prevVelocity - currVelocity));
 
-                // --- EXTREME RELAX CHEESE FIX 3: Acceleration Buff Nullification ---
+                //acceleration buff nerf
                 if (isRelax)
                 {
                     // Trivial to track acceleration/deceleration streams in Relax, reduce the buff by 80%

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates difficulty of "flow aim" - aiming pattern where player doesn't stop their cursor on every object and instead "flows" through them.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance, bool isRelax = false)
         {
             if (current.BaseObject is Spinner || current.Index <= 1 || current.Previous(0).BaseObject is Spinner)
                 return 0;
@@ -42,9 +42,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double flowDifficulty = currVelocity;
 
-            // Apply high circle size bonus to the base velocity.
-            // We use reduced CS bonus here because the bonus was made for an evaluator with a different d/t scaling
-            flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
+            // If Relax is active, I chose to completely strip the SmallCircleBonus for flowing objects. This can be highened if it feels too harsh.
+            if (!isRelax)
+            {
+                flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
+            }
 
             // Rhythm changes are harder to flow
             flowDifficulty *= 1 + Math.Min(0.25,
@@ -57,7 +59,25 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 double angularVelocity = angleDifferenceAdjusted / (osuCurrObj.AdjustedDeltaTime * 0.1);
 
                 // Low angular velocity flow (angles are consistent) is easier to follow than erratic flow
-                flowDifficulty *= 0.8 + Math.Sqrt(angularVelocity / 270.0);
+                double angularMultiplier = 0.8 + Math.Sqrt(angularVelocity / 270.0);
+
+                //this is for washing machines type streams 
+                if (isRelax)
+                {
+                    // Trigger threshold lowered to 1.2 used to be  (catches even medium-sized circular abuse)
+                    if (currVelocity > 1.2)
+                    {
+                        //The wider the curve is the harsher will be the  flow aim nerf, killing abuse maps 
+                        double circularAbusePenalty = DifficultyCalculationUtils.Smoothstep(angularVelocity, 0, 200);
+
+                        // Exponential velocity penalty: the larger the circle, the harder the multiplier drops, it should be able to kill pp compleately at cs0 
+                        double velocityPenalty = Math.Pow(1.2 / currVelocity, 2);
+
+                        angularMultiplier *= circularAbusePenalty + (1.0 - circularAbusePenalty) * velocityPenalty;
+                    }
+                }
+
+                flowDifficulty *= angularMultiplier;
             }
 
             // If all three notes are overlapping - don't reward bonuses as you don't have to do additional movement
@@ -93,6 +113,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 // Reward for % distance up to 125 / strainTime for overlaps where velocity is still changing.
                 double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime),
                     Math.Abs(prevVelocity - currVelocity));
+
+                // --- EXTREME RELAX CHEESE FIX 3: Acceleration Buff Nullification ---
+                if (isRelax)
+                {
+                    // Trivial to track acceleration/deceleration streams in Relax, reduce the buff by 80%
+                    overlapVelocityBuff *= 0.2;
+                }
 
                 flowDifficulty += overlapVelocityBuff *
                                   distRatio *

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -14,6 +14,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
     {
         private const double velocity_change_multiplier = 0.52;
 
+        // Multipliers for flow aim on relax
+        private const double flow_angular_velocity_scale = 270.0;
+        private const double relax_washing_machine_velocity_threshold = 1.2; // Speed needed to define the difference between a normal stream and a washing machine
+        private const double relax_circularity_angular_threshold = 200.0; // How sharp a player cursor should move in order to be awarded for it
+        private const double relax_acceleration_buff_multiplier = 0.2; //How much of the acceleration difficulty bonus the player keeps when relax is on
+
         /// <summary>
         /// Evaluates difficulty of "flow aim" - aiming pattern where player doesn't stop their cursor on every object and instead "flows" through them.
         /// </summary>
@@ -42,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double flowDifficulty = currVelocity;
 
-            // If Relax is active, I chose to completely strip the SmallCircleBonus for flowing objects. This can be highened if it feels too harsh.
+            // If Relax is active, I chose to completely strip the SmallCircleBonus for flowing objects. This can be heightened if it feels too harsh.
             if (!isRelax)
             {
                 flowDifficulty *= Math.Sqrt(osuCurrObj.SmallCircleBonus);
@@ -59,21 +65,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 double angularVelocity = angleDifferenceAdjusted / (osuCurrObj.AdjustedDeltaTime * 0.1);
 
                 // Low angular velocity flow (angles are consistent) is easier to follow than erratic flow
-                double angularMultiplier = 0.8 + Math.Sqrt(angularVelocity / 270.0);
+                double angularMultiplier = 0.8 + Math.Sqrt(angularVelocity / flow_angular_velocity_scale);
 
-                //this is for washing machines type streams 
+                // this is for washing machines type streams 
                 if (isRelax)
                 {
-                    // Trigger threshold highened to 1.2 used to be 1.0  (catches even medium-sized circular abuse)
-                    if (currVelocity > 1.2)
+                    // Trigger threshold heightened to 1.2 used to be 1.0 (catches even medium-sized circular abuse)
+                    if (currVelocity > relax_washing_machine_velocity_threshold)
                     {
-                        //The wider the curve is the harsher will be the  flow aim nerf, killing abuse maps 
-                        double circularAbusePenalty = DifficultyCalculationUtils.Smoothstep(angularVelocity, 0, 200);
+                        // The wider the curve is the harsher will be the flow aim nerf, killing abuse maps 
+                        double flowConsistencyKeep = DifficultyCalculationUtils.Smoothstep(angularVelocity, 0, relax_circularity_angular_threshold);
 
-                        // Exponential velocity penalty: the larger the circle, the harder the multiplier drops, it should be able to kill pp compleately at cs0 
-                        double velocityPenalty = Math.Pow(1.2 / currVelocity, 2);
+                        // Exponential velocity penalty: the larger the circle, the harder the multiplier drops, it should be able to kill pp completely at cs0 
+                        double velocityPenalty = Math.Pow(relax_washing_machine_velocity_threshold / currVelocity, 2);
 
-                        angularMultiplier *= circularAbusePenalty + (1.0 - circularAbusePenalty) * velocityPenalty;
+                        angularMultiplier *= flowConsistencyKeep + (1.0 - flowConsistencyKeep) * velocityPenalty;
                     }
                 }
 
@@ -114,11 +120,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
                 double overlapVelocityBuff = Math.Min(OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25 / Math.Min(osuCurrObj.AdjustedDeltaTime, osuLastObj.AdjustedDeltaTime),
                     Math.Abs(prevVelocity - currVelocity));
 
-                //acceleration buff nerf
+                // acceleration buff nerf
                 if (isRelax)
                 {
                     // Trivial to track acceleration/deceleration streams in Relax, reduce the buff by 80%
-                    overlapVelocityBuff *= 0.2;
+                    overlapVelocityBuff *= relax_acceleration_buff_multiplier;
                 }
 
                 flowDifficulty += overlapVelocityBuff *

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -73,9 +73,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double calculateModAdjustedDifficulty(DifficultyHitObject current)
         {
+            //boolean needed to identify if Relax is active to pass the context down to geometric evaluators
+            bool isRelax = Mods.Any(m => m is OsuModRelax);
+
             double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplierSnap;
             double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current) * skillMultiplierAgility;
-            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skillMultiplierFlow;
+
+            // Pass the isRelax flag to evaluate geometry correctly when relax is on
+            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders, isRelax) * skillMultiplierFlow;
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 


### PR DESCRIPTION
Added mainly 4 changes, 3 in the flowaim.cs and 1 in aim.cs
Now aim.cs is able to send a boolean to check if relax is on, could be useful for other reworks too in order to adjust our pp system, while the flowaimevaulator.cs has now the flow aim cs bonus available only for std scores,  rx will no longer get cs bonus (*flow aim only change, aim will still get low cs buffs*), also introduced a fix for washing machine patterns, and a nerf for the bonus for direction changes in streams.  
((ALL THIS FIXED ONLY APPLY FOR RX))
HOW IT WORKS:
----washing machine fix----
1) Requisites: 
in order to activate, the fix needs two condition, relax being turned on (duh) and a velocity > 1.2 this is needed otherwise slow aim control streams would get 0pp, this way we address only high flowy streams.
2) Curve analysis 
-If a stream with a sharp, wiggle snap is performed, the angle changes abruptly, thus we have an high angular velocity.
-During a washing machine the curve is way smoother, the cursor never stops or changes directions abruptly, its a continuous curve with very little angle changes, thus we have a low angular velocity
3) We pass this angular velocity into a function called SmoothStep, it works like a scale. If it detects that the trajectory is smooth and circular, it raises the value of a variable we called circularity up to 1.0. The more "perfect" the circle is, the higher this value gets. then we apply the nerf to RepetitionNerf = 1.0 - (circularity * 0.95). (with a max nerf of 95%).
----Velocity changes nerf----
WHY? In osu! std, if a stream has overlapping notes and the speed changes suddenly, the algorithm gives a buff called OverlapVelocityBuff, because adapting tapping speed and aiming speed requires high skill and tapping-aiming coordination.
In relax, this is not needed, the only difficulty is changing the direction of your aim, which in some streams could still become incredibly difficult, (example top diff of SOLID WYVERN) thus I adopted a change bringing keeping only the 20% of the original multiplier for relax scores
----High cs fix----
This is pretty straightforward, in normal osu! High cs is incredibly rewarded because it requires insane tapping coordination,
in relax, this coordination is not needed and the only difficulty is aiming the pattern which pretty much stays independent from circle size, the only difficulty stays from snapping on the first note of the stream, and that counts as snap aim and its thus rewarded with cs bonus, the rest of the stream however gets little to no diff gain from low cs. this fix aims to fix all those short low cs maps that rewarded insane amounts of pp for no reason (yes ALICE IN WONDERLAND im looking at you).
The fix completely removes the buff when relax is on.
