### PR TITLE
Add Downloaded / Not Downloaded filters to beatmap listing

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -17,6 +17,9 @@ using osu.Framework.Localisation;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Configuration;
+using osu.Game.Database;
+using osu.Game.Beatmaps;
+using osu.Game.Models;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -48,6 +51,19 @@ namespace osu.Game.Overlays.BeatmapListing
         /// </summary>
         private bool noMoreResults;
 
+        private HashSet<int> downloadedBeatmapSetIds = new HashSet<int>();
+
+        /// <summary>
+        /// Tracks how many extra pages we've auto-fetched for client-side filtering.
+        /// </summary>
+        private int autoFetchDepth;
+
+        /// <summary>
+        /// Accumulates results across multiple auto-fetched pages so they're
+        /// delivered as a single batch to the UI.
+        /// </summary>
+        private List<APIBeatmapSet> accumulatedSets = new List<APIBeatmapSet>();
+
         /// <summary>
         /// The current page fetched of results (zero index).
         /// </summary>
@@ -71,6 +87,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
         [Resolved]
         private IAPIProvider api { get; set; }
+
+        private RealmAccess realm = null!;
 
         private IBindable<APIUser> apiUser;
 
@@ -137,19 +155,20 @@ namespace osu.Game.Overlays.BeatmapListing
         private OsuConfigManager config { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
+        private void load(OverlayColourProvider colourProvider, IAPIProvider api, RealmAccess realm)
         {
             sortControlBackground.Colour = colourProvider.Background4;
+            this.realm = realm;
         }
 
         public void Search(string query)
-            => Schedule(() => searchControl.Query.Value = query);
+        => Schedule(() => searchControl.Query.Value = query);
 
         public void FilterGenre(SearchGenre genre)
-            => Schedule(() => searchControl.Genre.Value = genre);
+        => Schedule(() => searchControl.Genre.Value = genre);
 
         public void FilterLanguage(SearchLanguage language)
-            => Schedule(() => searchControl.Language.Value = language);
+        => Schedule(() => searchControl.Language.Value = language);
 
         protected override void LoadComplete()
         {
@@ -176,6 +195,7 @@ namespace osu.Game.Overlays.BeatmapListing
             searchControl.Extra.CollectionChanged += (_, _) => queueUpdateSearch();
             searchControl.Ranks.CollectionChanged += (_, _) => queueUpdateSearch();
             searchControl.Played.BindValueChanged(_ => queueUpdateSearch());
+            searchControl.Downloaded.BindValueChanged(_ => queueUpdateSearch());
             searchControl.ExplicitContent.BindValueChanged(_ => queueUpdateSearch());
 
             sortControl.Current.BindValueChanged(_ => queueUpdateSearch());
@@ -183,6 +203,26 @@ namespace osu.Game.Overlays.BeatmapListing
 
             apiUser = api.LocalUser.GetBoundCopy();
             apiUser.BindValueChanged(_ => queueUpdateSearch());
+
+            // Pre-populate downloaded beatmap set IDs for client-side filtering
+            Scheduler.Add(() =>
+            {
+                if (realm != null)
+                {
+                    downloadedBeatmapSetIds = realm.Run(r =>
+                    {
+                        var sets = r.All<BeatmapSetInfo>()
+                        .Where(s => !s.DeletePending && s.OnlineID > 0)
+                        .AsEnumerable()
+                        .ToList();
+
+                        var ids = new HashSet<int>();
+                        foreach (var s in sets)
+                            ids.Add(s.OnlineID);
+                        return ids;
+                    });
+                }
+            });
         }
 
         public void TakeFocus() => searchControl.TakeFocus();
@@ -224,129 +264,332 @@ namespace osu.Game.Overlays.BeatmapListing
             }, queryTextChanged ? 500 : 100);
         }
 
-        private void performRequest()
+        /// <summary>
+        /// Builds cover URLs for a beatmap set based on its OnlineID.
+        /// Uses JSON deserialization so property access matches the API response format.
+        /// </summary>
+        private static BeatmapSetOnlineCovers buildCovers(int onlineID)
         {
-            getSetsRequest = new SearchBeatmapSetsRequest(
-                searchControl.Query.Value,
-                searchControl.Ruleset.Value,
-                lastResponse?.Cursor,
-                searchControl.General,
-                searchControl.Category.Value,
-                sortControl.Current.Value,
-                sortControl.SortDirection.Value,
-                searchControl.Genre.Value,
-                searchControl.Language.Value,
-                searchControl.Extra,
-                searchControl.Ranks,
-                searchControl.Played.Value,
-                searchControl.ExplicitContent.Value);
+            string json = $@"{{
+            ""cover"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/cover.jpg"",
+            ""cover@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/cover@2x.jpg"",
+            ""list"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/list.jpg"",
+            ""list@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/list@2x.jpg"",
+            ""card"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/card.jpg"",
+            ""card@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/card@2x.jpg"",
+            ""slimcover"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/slimcover.jpg"",
+            ""slimcover@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/slimcover@2x.jpg""
+        }}";
 
-            getSetsRequest.Success += response =>
+        return Newtonsoft.Json.JsonConvert.DeserializeObject<BeatmapSetOnlineCovers>(json);
+}
+
+/// <summary>
+/// Queries the local Realm database for downloaded beatmaps and converts them
+/// to <see cref="APIBeatmapSet"/> objects for display. Used when the
+/// "Downloaded" filter is active — no API calls needed.
+/// </summary>
+private void performLocalSearch()
+{
+    var query = searchControl.Query.Value ?? string.Empty;
+    var category = searchControl.Category.Value;
+    var ruleset = searchControl.Ruleset.Value;
+    var played = searchControl.Played.Value;
+    var sortCriteria = sortControl.Current.Value;
+    var sortDirection = sortControl.SortDirection.Value;
+
+    Scheduler.Add(() =>
+    {
+        var allSets = realm.Run(r =>
+        {
+            var sets = r.All<BeatmapSetInfo>()
+            .Where(s => !s.DeletePending && s.OnlineID > 0)
+            .AsEnumerable()
+            .ToList();
+
+            // --- Filter: Status (Category) ---
+            if (category == SearchCategory.Leaderboard || category == SearchCategory.Ranked)
+                sets = sets.Where(s =>
+                s.Status == BeatmapOnlineStatus.Ranked ||
+                s.Status == BeatmapOnlineStatus.Approved).ToList();
+            else if (category == SearchCategory.Qualified)
+                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Qualified).ToList();
+            else if (category == SearchCategory.Loved)
+                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Loved).ToList();
+            else if (category == SearchCategory.Pending || category == SearchCategory.Wip)
+                sets = sets.Where(s =>
+                s.Status == BeatmapOnlineStatus.Pending ||
+                s.Status == BeatmapOnlineStatus.WIP).ToList();
+            else if (category == SearchCategory.Graveyard)
+                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Graveyard).ToList();
+
+            // --- Filter: Ruleset ---
+            if (ruleset.OnlineID >= 0)
             {
-                var sets = response.BeatmapSets.ToList();
+                sets = sets.Where(s =>
+                s.Beatmaps.Any(b => b.Ruleset.OnlineID == ruleset.OnlineID)
+                ).ToList();
+            }
 
-                // If the previous request returned a null cursor, the API is indicating we can't paginate further (maybe there are no more beatmaps left).
-                if (sets.Count == 0 || response.Cursor == null)
-                    noMoreResults = true;
+            // --- Filter: Played / Unplayed ---
+            if (played == SearchPlayed.Played)
+                sets = sets.Where(s => s.Beatmaps.Any(b => b.LastPlayed != null)).ToList();
+            else if (played == SearchPlayed.Unplayed)
+                sets = sets.Where(s => s.Beatmaps.All(b => b.LastPlayed == null)).ToList();
 
-                if (CurrentPage == 0)
-                    searchControl.BeatmapSet = sets.FirstOrDefault();
+            // --- Filter: Search text ---
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var terms = query.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                sets = sets.Where(s =>
+                terms.All(t =>
+                s.Beatmaps.Any(b =>
+                (b.Metadata.Title ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.TitleUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.Artist ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.ArtistUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.Author.Username ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.Source ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                (b.Metadata.Tags ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                b.OnlineID.ToString() == t
+                )
+                )
+                ).ToList();
+            }
 
+            return sets;
+        });
+
+        // Convert BeatmapSetInfo → APIBeatmapSet for the display layer
+        var apiSets = allSets.Select(s =>
+        {
+            var first = s.Beatmaps.FirstOrDefault();
+            return new APIBeatmapSet
+            {
+                OnlineID = s.OnlineID,
+                Status = s.Status,
+                Title = first?.Metadata.Title ?? "",
+                TitleUnicode = first?.Metadata.TitleUnicode ?? "",
+                Artist = first?.Metadata.Artist ?? "",
+                ArtistUnicode = first?.Metadata.ArtistUnicode ?? "",
+                AuthorString = first?.Metadata.Author.Username ?? "",
+                AuthorID = first?.Metadata.Author.OnlineID ?? 0,
+                Source = first?.Metadata.Source ?? "",
+                Tags = first?.Metadata.Tags ?? "",
+                BPM = first?.BPM ?? 0,
+                Covers = buildCovers(s.OnlineID),
+                                     Beatmaps = s.Beatmaps.Select(b => new APIBeatmap
+                                     {
+                                         DifficultyName = b.DifficultyName,
+                                         StarRating = b.StarRating,
+                                         OnlineID = b.OnlineID,
+                                         Length = b.Length,
+                                         BPM = b.BPM,
+                                         CircleSize = b.Difficulty.CircleSize,
+                                         ApproachRate = b.Difficulty.ApproachRate,
+                                         OverallDifficulty = b.Difficulty.OverallDifficulty,
+                                         DrainRate = b.Difficulty.DrainRate,
+                                         RulesetID = b.Ruleset.OnlineID,
+                                         Status = b.Status,
+                                     }).ToArray(),
+            };
+        }).ToList();
+
+        // --- Sort ---
+        bool descending = sortDirection == SortDirection.Descending;
+        apiSets = sortCriteria switch
+        {
+            SortCriteria.Title => descending
+            ? apiSets.OrderByDescending(s => s.Title).ToList()
+            : apiSets.OrderBy(s => s.Title).ToList(),
+                  SortCriteria.Artist => descending
+                  ? apiSets.OrderByDescending(s => s.Artist).ToList()
+                  : apiSets.OrderBy(s => s.Artist).ToList(),
+                  SortCriteria.Difficulty => descending
+                  ? apiSets.OrderByDescending(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList()
+                  : apiSets.OrderBy(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList(),
+                  SortCriteria.Updated => descending
+                  ? apiSets.OrderByDescending(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList()
+                  : apiSets.OrderBy(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList(),
+                  _ => apiSets.OrderByDescending(s => s.Ranked).ToList(),
+        };
+
+        noMoreResults = true;
+
+        if (apiSets.Count > 0)
+            searchControl.BeatmapSet = apiSets.First();
+
+        var resultsReturned = SearchResult.ResultsReturned(apiSets);
+        SearchFinished?.Invoke(resultsReturned);
+    });
+}
+
+private void performRequest()
+{
+    // "Downloaded" filter: use local database only, no API calls needed.
+    if (searchControl.Downloaded.Value == SearchDownloaded.Downloaded)
+    {
+        performLocalSearch();
+        return;
+    }
+
+    var downloadedIds = downloadedBeatmapSetIds;
+
+    getSetsRequest = new SearchBeatmapSetsRequest(
+        searchControl.Query.Value,
+        searchControl.Ruleset.Value,
+        lastResponse?.Cursor,
+        searchControl.General,
+        searchControl.Category.Value,
+        sortControl.Current.Value,
+        sortControl.SortDirection.Value,
+        searchControl.Genre.Value,
+        searchControl.Language.Value,
+        searchControl.Extra,
+        searchControl.Ranks,
+        searchControl.Played.Value,
+        searchControl.ExplicitContent.Value);
+
+    getSetsRequest.Success += response =>
+    {
+        var sets = response.BeatmapSets.ToList();
+
+        // Client-side filter: Not Downloaded
+        if (searchControl.Downloaded.Value == SearchDownloaded.NotDownloaded)
+        {
+            sets = sets.Where(s => !downloadedIds.Contains(s.OnlineID)).ToList();
+
+            // Auto-fetch more pages if this page was too sparse
+            bool shouldFetchMore = sets.Count < 10
+            && response.Cursor != null
+            && autoFetchDepth < 15;
+
+            if (shouldFetchMore)
+            {
+                autoFetchDepth++;
                 lastResponse = response;
                 getSetsRequest = null;
 
-                // check if a non-supporter used supporter-only filters
-                if (!api.LocalUser.Value.IsSupporter)
-                {
-                    List<LocalisableString> filters = new List<LocalisableString>();
+                accumulatedSets.AddRange(sets);
 
-                    if (searchControl.Played.Value != SearchPlayed.Any)
-                        filters.Add(BeatmapsStrings.ListingSearchFiltersPlayed);
+                performRequest();
+                return;
+            }
 
-                    if (searchControl.Ranks.Any())
-                        filters.Add(BeatmapsStrings.ListingSearchFiltersRank);
-
-                    if (filters.Any())
-                    {
-                        var supporterOnlyFilters = SearchResult.SupporterOnlyFilters(filters);
-                        SearchFinished?.Invoke(supporterOnlyFilters);
-                        return;
-                    }
-                }
-
-                var resultsReturned = SearchResult.ResultsReturned(sets);
-                SearchFinished?.Invoke(resultsReturned);
-            };
-
-            api.Queue(getSetsRequest);
-        }
-
-        private void resetSearch()
-        {
-            noMoreResults = false;
-            CurrentPage = 0;
-
-            lastResponse = null;
-
-            getSetsRequest?.Cancel();
-            getSetsRequest = null;
-
-            queryChangedDebounce?.Cancel();
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            resetSearch();
-
-            base.Dispose(isDisposing);
-        }
-
-        /// <summary>
-        /// Indicates the type of result of a user-requested beatmap search.
-        /// </summary>
-        public enum SearchResultType
-        {
-            /// <summary>
-            /// Actual results have been returned from API.
-            /// </summary>
-            ResultsReturned,
-
-            /// <summary>
-            /// The user is not a supporter, but used supporter-only search filters.
-            /// </summary>
-            SupporterOnlyFilters
-        }
-
-        /// <summary>
-        /// Describes the result of a user-requested beatmap search.
-        /// </summary>
-        public struct SearchResult
-        {
-            public SearchResultType Type { get; private set; }
-
-            /// <summary>
-            /// Contains the beatmap sets returned from API.
-            /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.ResultsReturned"/>.
-            /// </summary>
-            public List<APIBeatmapSet> Results { get; private set; }
-
-            /// <summary>
-            /// Contains the names of supporter-only filters requested by the user.
-            /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.SupporterOnlyFilters"/>.
-            /// </summary>
-            public List<LocalisableString> SupporterOnlyFiltersUsed { get; private set; }
-
-            public static SearchResult ResultsReturned(List<APIBeatmapSet> results) => new SearchResult
+            if (accumulatedSets.Count > 0)
             {
-                Type = SearchResultType.ResultsReturned,
-                Results = results,
-            };
-
-            public static SearchResult SupporterOnlyFilters(List<LocalisableString> filters) => new SearchResult
-            {
-                Type = SearchResultType.SupporterOnlyFilters,
-                SupporterOnlyFiltersUsed = filters
-            };
+                accumulatedSets.AddRange(sets);
+                sets = accumulatedSets;
+                accumulatedSets = new List<APIBeatmapSet>();
+            }
         }
-    }
+
+        autoFetchDepth = 0;
+        accumulatedSets.Clear();
+
+        if (sets.Count == 0 || response.Cursor == null)
+            noMoreResults = true;
+
+        if (CurrentPage == 0)
+            searchControl.BeatmapSet = sets.FirstOrDefault();
+
+        lastResponse = response;
+        getSetsRequest = null;
+
+        if (!api.LocalUser.Value.IsSupporter)
+        {
+            List<LocalisableString> filters = new List<LocalisableString>();
+
+            if (searchControl.Played.Value != SearchPlayed.Any)
+                filters.Add(BeatmapsStrings.ListingSearchFiltersPlayed);
+
+            if (searchControl.Ranks.Any())
+                filters.Add(BeatmapsStrings.ListingSearchFiltersRank);
+
+            if (filters.Any())
+            {
+                var supporterOnlyFilters = SearchResult.SupporterOnlyFilters(filters);
+                SearchFinished?.Invoke(supporterOnlyFilters);
+                return;
+            }
+        }
+
+        var resultsReturned = SearchResult.ResultsReturned(sets);
+        SearchFinished?.Invoke(resultsReturned);
+    };
+
+    api.Queue(getSetsRequest);
+}
+
+private void resetSearch()
+{
+    noMoreResults = false;
+    CurrentPage = 0;
+
+    lastResponse = null;
+
+    getSetsRequest?.Cancel();
+    getSetsRequest = null;
+
+    queryChangedDebounce?.Cancel();
+
+    autoFetchDepth = 0;
+    accumulatedSets.Clear();
+}
+
+protected override void Dispose(bool isDisposing)
+{
+    resetSearch();
+
+    base.Dispose(isDisposing);
+}
+
+/// <summary>
+/// Indicates the type of result of a user-requested beatmap search.
+/// </summary>
+public enum SearchResultType
+{
+    /// <summary>
+    /// Actual results have been returned from API.
+    /// </summary>
+    ResultsReturned,
+
+    /// <summary>
+    /// The user is not a supporter, but used supporter-only search filters.
+    /// </summary>
+    SupporterOnlyFilters
+}
+
+/// <summary>
+/// Describes the result of a user-requested beatmap search.
+/// </summary>
+public struct SearchResult
+{
+    public SearchResultType Type { get; private set; }
+
+    /// <summary>
+    /// Contains the beatmap sets returned from API.
+    /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.ResultsReturned"/>.
+    /// </summary>
+    public List<APIBeatmapSet> Results { get; private set; }
+
+    /// <summary>
+    /// Contains the names of supporter-only filters requested by the user.
+    /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.SupporterOnlyFilters"/>.
+    /// </summary>
+    public List<LocalisableString> SupporterOnlyFiltersUsed { get; private set; }
+
+    public static SearchResult ResultsReturned(List<APIBeatmapSet> results) => new SearchResult
+    {
+        Type = SearchResultType.ResultsReturned,
+        Results = results,
+    };
+
+    public static SearchResult SupporterOnlyFilters(List<LocalisableString> filters) => new SearchResult
+    {
+        Type = SearchResultType.SupporterOnlyFilters,
+        SupporterOnlyFiltersUsed = filters
+    };
+}
+}
 }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -51,9 +51,14 @@ namespace osu.Game.Overlays.BeatmapListing
         /// </summary>
         private bool noMoreResults;
 
-        private HashSet<int> downloadedBeatmapSetIds = new HashSet<int>();
+        /// <summary>
+        /// Whether there are more pages available from the API.
+        /// False when the cursor is exhausted. Used by the overlay to decide
+        /// whether to show a "not found" dead-end or fetch the next page.
+        /// </summary>
+        public bool HasMorePages => !noMoreResults;
 
-        private int notDownloadedRetries;
+        private HashSet<int> downloadedBeatmapSetIds = new HashSet<int>();
 
         /// <summary>
         /// The current page fetched of results (zero index).
@@ -463,18 +468,17 @@ namespace osu.Game.Overlays.BeatmapListing
                     sets = sets.Where(s => !downloadedIds.Contains(s.OnlineID)).ToList();
 
                     // If every result on this page was already downloaded but more pages
-                    // exist, auto-fetch the next one. Cap at 5 retries to limit API usage.
-                    if (sets.Count == 0 && response.Cursor != null && notDownloadedRetries < 5)
+                    // exist, skip to the next one. This only triggers when a page is
+                    // completely empty, which is a rare edge case — the API load is
+                    // equivalent to what the user would generate by manually paginating.
+                    if (sets.Count == 0 && response.Cursor != null)
                     {
-                        notDownloadedRetries++;
                         lastResponse = response;
                         getSetsRequest = null;
                         performRequest();
                         return;
                     }
                 }
-
-                notDownloadedRetries = 0;
 
                 if (response.Cursor == null)
                     noMoreResults = true;
@@ -521,8 +525,6 @@ namespace osu.Game.Overlays.BeatmapListing
             getSetsRequest = null;
 
             queryChangedDebounce?.Cancel();
-
-            notDownloadedRetries = 0;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -158,13 +158,13 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         public void Search(string query)
-        => Schedule(() => searchControl.Query.Value = query);
+            => Schedule(() => searchControl.Query.Value = query);
 
         public void FilterGenre(SearchGenre genre)
-        => Schedule(() => searchControl.Genre.Value = genre);
+            => Schedule(() => searchControl.Genre.Value = genre);
 
         public void FilterLanguage(SearchLanguage language)
-        => Schedule(() => searchControl.Language.Value = language);
+            => Schedule(() => searchControl.Language.Value = language);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -19,7 +20,6 @@ using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Beatmaps;
-using osu.Game.Models;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -53,16 +53,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private HashSet<int> downloadedBeatmapSetIds = new HashSet<int>();
 
-        /// <summary>
-        /// Tracks how many extra pages we've auto-fetched for client-side filtering.
-        /// </summary>
-        private int autoFetchDepth;
-
-        /// <summary>
-        /// Accumulates results across multiple auto-fetched pages so they're
-        /// delivered as a single batch to the UI.
-        /// </summary>
-        private List<APIBeatmapSet> accumulatedSets = new List<APIBeatmapSet>();
+        private int notDownloadedRetries;
 
         /// <summary>
         /// The current page fetched of results (zero index).
@@ -88,7 +79,8 @@ namespace osu.Game.Overlays.BeatmapListing
         [Resolved]
         private IAPIProvider api { get; set; }
 
-        private RealmAccess realm = null!;
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
 
         private IBindable<APIUser> apiUser;
 
@@ -155,10 +147,9 @@ namespace osu.Game.Overlays.BeatmapListing
         private OsuConfigManager config { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, IAPIProvider api, RealmAccess realm)
+        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
         {
             sortControlBackground.Colour = colourProvider.Background4;
-            this.realm = realm;
         }
 
         public void Search(string query)
@@ -195,7 +186,11 @@ namespace osu.Game.Overlays.BeatmapListing
             searchControl.Extra.CollectionChanged += (_, _) => queueUpdateSearch();
             searchControl.Ranks.CollectionChanged += (_, _) => queueUpdateSearch();
             searchControl.Played.BindValueChanged(_ => queueUpdateSearch());
-            searchControl.Downloaded.BindValueChanged(_ => queueUpdateSearch());
+            searchControl.Downloaded.BindValueChanged(_ =>
+            {
+                refreshDownloadedIds();
+                queueUpdateSearch();
+            });
             searchControl.ExplicitContent.BindValueChanged(_ => queueUpdateSearch());
 
             sortControl.Current.BindValueChanged(_ => queueUpdateSearch());
@@ -203,26 +198,6 @@ namespace osu.Game.Overlays.BeatmapListing
 
             apiUser = api.LocalUser.GetBoundCopy();
             apiUser.BindValueChanged(_ => queueUpdateSearch());
-
-            // Pre-populate downloaded beatmap set IDs for client-side filtering
-            Scheduler.Add(() =>
-            {
-                if (realm != null)
-                {
-                    downloadedBeatmapSetIds = realm.Run(r =>
-                    {
-                        var sets = r.All<BeatmapSetInfo>()
-                        .Where(s => !s.DeletePending && s.OnlineID > 0)
-                        .AsEnumerable()
-                        .ToList();
-
-                        var ids = new HashSet<int>();
-                        foreach (var s in sets)
-                            ids.Add(s.OnlineID);
-                        return ids;
-                    });
-                }
-            });
         }
 
         public void TakeFocus() => searchControl.TakeFocus();
@@ -265,331 +240,344 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         /// <summary>
-        /// Builds cover URLs for a beatmap set based on its OnlineID.
-        /// Uses JSON deserialization so property access matches the API response format.
+        /// Refreshes the cached set of locally-downloaded beatmap set IDs.
+        /// Called when the Downloaded filter tab changes so the data stays
+        /// current if maps are imported or deleted while the listing is open.
         /// </summary>
-        private static BeatmapSetOnlineCovers buildCovers(int onlineID)
+        private void refreshDownloadedIds()
         {
-            string json = $@"{{
-            ""cover"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/cover.jpg"",
-            ""cover@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/cover@2x.jpg"",
-            ""list"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/list.jpg"",
-            ""list@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/list@2x.jpg"",
-            ""card"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/card.jpg"",
-            ""card@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/card@2x.jpg"",
-            ""slimcover"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/slimcover.jpg"",
-            ""slimcover@2x"": ""https://assets.ppy.sh/beatmaps/{onlineID}/covers/slimcover@2x.jpg""
-        }}";
+            if (realm == null) return;
 
-        return Newtonsoft.Json.JsonConvert.DeserializeObject<BeatmapSetOnlineCovers>(json);
-}
-
-/// <summary>
-/// Queries the local Realm database for downloaded beatmaps and converts them
-/// to <see cref="APIBeatmapSet"/> objects for display. Used when the
-/// "Downloaded" filter is active — no API calls needed.
-/// </summary>
-private void performLocalSearch()
-{
-    var query = searchControl.Query.Value ?? string.Empty;
-    var category = searchControl.Category.Value;
-    var ruleset = searchControl.Ruleset.Value;
-    var played = searchControl.Played.Value;
-    var sortCriteria = sortControl.Current.Value;
-    var sortDirection = sortControl.SortDirection.Value;
-
-    Scheduler.Add(() =>
-    {
-        var allSets = realm.Run(r =>
-        {
-            var sets = r.All<BeatmapSetInfo>()
-            .Where(s => !s.DeletePending && s.OnlineID > 0)
-            .AsEnumerable()
-            .ToList();
-
-            // --- Filter: Status (Category) ---
-            if (category == SearchCategory.Leaderboard || category == SearchCategory.Ranked)
-                sets = sets.Where(s =>
-                s.Status == BeatmapOnlineStatus.Ranked ||
-                s.Status == BeatmapOnlineStatus.Approved).ToList();
-            else if (category == SearchCategory.Qualified)
-                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Qualified).ToList();
-            else if (category == SearchCategory.Loved)
-                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Loved).ToList();
-            else if (category == SearchCategory.Pending || category == SearchCategory.Wip)
-                sets = sets.Where(s =>
-                s.Status == BeatmapOnlineStatus.Pending ||
-                s.Status == BeatmapOnlineStatus.WIP).ToList();
-            else if (category == SearchCategory.Graveyard)
-                sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Graveyard).ToList();
-
-            // --- Filter: Ruleset ---
-            if (ruleset.OnlineID >= 0)
+            downloadedBeatmapSetIds = realm.Run(r =>
             {
-                sets = sets.Where(s =>
-                s.Beatmaps.Any(b => b.Ruleset.OnlineID == ruleset.OnlineID)
-                ).ToList();
+                var sets = r.All<BeatmapSetInfo>()
+                .Where(s => !s.DeletePending && s.OnlineID > 0)
+                .AsEnumerable()
+                .ToList();
+
+                var ids = new HashSet<int>();
+                foreach (var s in sets)
+                    ids.Add(s.OnlineID);
+                return ids;
+            });
+        }
+
+        /// <summary>
+        /// Queries the local Realm database for downloaded beatmaps and converts them
+        /// to <see cref="APIBeatmapSet"/> objects for display. Used when the
+        /// "Downloaded" filter is active — no API calls needed.
+        /// </summary>
+        /// <remarks>
+        /// The following server-side filters have no local equivalent and are
+        /// silently ignored when "Downloaded" is active:
+        ///   - General (Recommended, Converts, Follows, Spotlights, Featured Artists)
+        ///   - Genre
+        ///   - Language
+        ///   - Extra (Video, Storyboard)
+        ///   - Ranks (score rank achieved)
+        ///   - Explicit Content
+        ///
+        /// These filters rely on data only available from the osu! API and are
+        /// not stored in the local beatmap database. Only Status (Category),
+        /// Ruleset, Played, and text search are applied to local results.
+        /// </remarks>
+        private void performLocalSearch()
+        {
+            var query = searchControl.Query.Value ?? string.Empty;
+            var category = searchControl.Category.Value;
+            var ruleset = searchControl.Ruleset.Value;
+            var played = searchControl.Played.Value;
+            var sortCriteria = sortControl.Current.Value;
+            var sortDirection = sortControl.SortDirection.Value;
+
+            // Run the heavy realm query + filtering + projection off the update thread
+            // to avoid hitching frames on large libraries.
+            Task.Run(() =>
+            {
+                var apiSets = realm.Run(r =>
+                {
+                    var sets = r.All<BeatmapSetInfo>()
+                    .Where(s => !s.DeletePending && s.OnlineID > 0)
+                    .AsEnumerable()
+                    .ToList();
+
+                    // --- Filter: Status (Category) ---
+                    if (category == SearchCategory.Leaderboard || category == SearchCategory.Ranked)
+                        sets = sets.Where(s =>
+                        s.Status == BeatmapOnlineStatus.Ranked ||
+                        s.Status == BeatmapOnlineStatus.Approved).ToList();
+                    else if (category == SearchCategory.Qualified)
+                        sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Qualified).ToList();
+                    else if (category == SearchCategory.Loved)
+                        sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Loved).ToList();
+                    else if (category == SearchCategory.Pending || category == SearchCategory.Wip)
+                        sets = sets.Where(s =>
+                        s.Status == BeatmapOnlineStatus.Pending ||
+                        s.Status == BeatmapOnlineStatus.WIP).ToList();
+                    else if (category == SearchCategory.Graveyard)
+                        sets = sets.Where(s => s.Status == BeatmapOnlineStatus.Graveyard).ToList();
+
+                    // --- Filter: Ruleset ---
+                    if (ruleset.OnlineID >= 0)
+                    {
+                        sets = sets.Where(s =>
+                        s.Beatmaps.Any(b => b.Ruleset.OnlineID == ruleset.OnlineID)
+                        ).ToList();
+                    }
+
+                    // --- Filter: Played / Unplayed ---
+                    if (played == SearchPlayed.Played)
+                        sets = sets.Where(s => s.Beatmaps.Any(b => b.LastPlayed != null)).ToList();
+                    else if (played == SearchPlayed.Unplayed)
+                        sets = sets.Where(s => s.Beatmaps.All(b => b.LastPlayed == null)).ToList();
+
+                    // --- Filter: Search text ---
+                    if (!string.IsNullOrWhiteSpace(query))
+                    {
+                        var terms = query.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                        sets = sets.Where(s =>
+                        terms.All(t =>
+                        s.Beatmaps.Any(b =>
+                        (b.Metadata.Title ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.TitleUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.Artist ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.ArtistUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.Author.Username ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.Source ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        (b.Metadata.Tags ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
+                        b.OnlineID.ToString() == t
+                        )
+                        )
+                        ).ToList();
+                    }
+
+                    // Convert BeatmapSetInfo → APIBeatmapSet inside realm.Run
+                    return sets.Select(s =>
+                    {
+                        var first = s.Beatmaps.FirstOrDefault();
+                        return new APIBeatmapSet
+                        {
+                            OnlineID = s.OnlineID,
+                            Status = s.Status,
+                            Title = first?.Metadata.Title ?? "",
+                            TitleUnicode = first?.Metadata.TitleUnicode ?? "",
+                            Artist = first?.Metadata.Artist ?? "",
+                            ArtistUnicode = first?.Metadata.ArtistUnicode ?? "",
+                            AuthorString = first?.Metadata.Author.Username ?? "",
+                            AuthorID = first?.Metadata.Author.OnlineID ?? 0,
+                            Source = first?.Metadata.Source ?? "",
+                            Tags = first?.Metadata.Tags ?? "",
+                            BPM = first?.BPM ?? 0,
+                            Covers = new BeatmapSetOnlineCovers
+                            {
+                                CoverLowRes = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/cover.jpg",
+                                Cover = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/cover@2x.jpg",
+                                CardLowRes = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/card.jpg",
+                                Card = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/card@2x.jpg",
+                                ListLowRes = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/list.jpg",
+                                List = $"https://assets.ppy.sh/beatmaps/{s.OnlineID}/covers/list@2x.jpg",
+                            },
+                            Beatmaps = s.Beatmaps.Select(b => new APIBeatmap
+                            {
+                                DifficultyName = b.DifficultyName,
+                                StarRating = b.StarRating,
+                                OnlineID = b.OnlineID,
+                                Length = b.Length,
+                                BPM = b.BPM,
+                                CircleSize = b.Difficulty.CircleSize,
+                                ApproachRate = b.Difficulty.ApproachRate,
+                                OverallDifficulty = b.Difficulty.OverallDifficulty,
+                                DrainRate = b.Difficulty.DrainRate,
+                                RulesetID = b.Ruleset.OnlineID,
+                                Status = b.Status,
+                            }).ToArray(),
+                        };
+                    }).ToList();
+                });
+
+                // --- Sort ---
+                bool descending = sortDirection == SortDirection.Descending;
+                apiSets = sortCriteria switch
+                {
+                    SortCriteria.Title => descending
+                    ? apiSets.OrderByDescending(s => s.Title).ToList()
+                    : apiSets.OrderBy(s => s.Title).ToList(),
+                     SortCriteria.Artist => descending
+                     ? apiSets.OrderByDescending(s => s.Artist).ToList()
+                     : apiSets.OrderBy(s => s.Artist).ToList(),
+                     SortCriteria.Difficulty => descending
+                     ? apiSets.OrderByDescending(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList()
+                     : apiSets.OrderBy(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList(),
+                     SortCriteria.Updated => descending
+                     ? apiSets.OrderByDescending(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList()
+                     : apiSets.OrderBy(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList(),
+                     _ => apiSets.OrderByDescending(s => s.Ranked).ToList(),
+                };
+
+                // Marshal results back to the update thread
+                Scheduler.Add(() =>
+                {
+                    noMoreResults = true;
+
+                    if (apiSets.Count > 0)
+                        searchControl.BeatmapSet = apiSets.First();
+
+                    SearchFinished?.Invoke(SearchResult.ResultsReturned(apiSets));
+                });
+            });
+        }
+
+        private void performRequest()
+        {
+            // "Downloaded" filter: use local database only, no API calls needed.
+            if (searchControl.Downloaded.Value == SearchDownloaded.Downloaded)
+            {
+                performLocalSearch();
+                return;
             }
 
-            // --- Filter: Played / Unplayed ---
-            if (played == SearchPlayed.Played)
-                sets = sets.Where(s => s.Beatmaps.Any(b => b.LastPlayed != null)).ToList();
-            else if (played == SearchPlayed.Unplayed)
-                sets = sets.Where(s => s.Beatmaps.All(b => b.LastPlayed == null)).ToList();
+            var downloadedIds = downloadedBeatmapSetIds;
 
-            // --- Filter: Search text ---
-            if (!string.IsNullOrWhiteSpace(query))
+            getSetsRequest = new SearchBeatmapSetsRequest(
+                searchControl.Query.Value,
+                searchControl.Ruleset.Value,
+                lastResponse?.Cursor,
+                searchControl.General,
+                searchControl.Category.Value,
+                sortControl.Current.Value,
+                sortControl.SortDirection.Value,
+                searchControl.Genre.Value,
+                searchControl.Language.Value,
+                searchControl.Extra,
+                searchControl.Ranks,
+                searchControl.Played.Value,
+                searchControl.ExplicitContent.Value);
+
+            getSetsRequest.Success += response =>
             {
-                var terms = query.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                sets = sets.Where(s =>
-                terms.All(t =>
-                s.Beatmaps.Any(b =>
-                (b.Metadata.Title ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.TitleUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.Artist ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.ArtistUnicode ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.Author.Username ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.Source ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                (b.Metadata.Tags ?? "").Contains(t, StringComparison.OrdinalIgnoreCase) ||
-                b.OnlineID.ToString() == t
-                )
-                )
-                ).ToList();
-            }
+                var sets = response.BeatmapSets.ToList();
 
-            return sets;
-        });
+                // Client-side filter: Not Downloaded
+                if (searchControl.Downloaded.Value == SearchDownloaded.NotDownloaded)
+                {
+                    sets = sets.Where(s => !downloadedIds.Contains(s.OnlineID)).ToList();
 
-        // Convert BeatmapSetInfo → APIBeatmapSet for the display layer
-        var apiSets = allSets.Select(s =>
-        {
-            var first = s.Beatmaps.FirstOrDefault();
-            return new APIBeatmapSet
-            {
-                OnlineID = s.OnlineID,
-                Status = s.Status,
-                Title = first?.Metadata.Title ?? "",
-                TitleUnicode = first?.Metadata.TitleUnicode ?? "",
-                Artist = first?.Metadata.Artist ?? "",
-                ArtistUnicode = first?.Metadata.ArtistUnicode ?? "",
-                AuthorString = first?.Metadata.Author.Username ?? "",
-                AuthorID = first?.Metadata.Author.OnlineID ?? 0,
-                Source = first?.Metadata.Source ?? "",
-                Tags = first?.Metadata.Tags ?? "",
-                BPM = first?.BPM ?? 0,
-                Covers = buildCovers(s.OnlineID),
-                                     Beatmaps = s.Beatmaps.Select(b => new APIBeatmap
-                                     {
-                                         DifficultyName = b.DifficultyName,
-                                         StarRating = b.StarRating,
-                                         OnlineID = b.OnlineID,
-                                         Length = b.Length,
-                                         BPM = b.BPM,
-                                         CircleSize = b.Difficulty.CircleSize,
-                                         ApproachRate = b.Difficulty.ApproachRate,
-                                         OverallDifficulty = b.Difficulty.OverallDifficulty,
-                                         DrainRate = b.Difficulty.DrainRate,
-                                         RulesetID = b.Ruleset.OnlineID,
-                                         Status = b.Status,
-                                     }).ToArray(),
-            };
-        }).ToList();
+                    // If every result on this page was already downloaded but more pages
+                    // exist, auto-fetch the next one. Cap at 5 retries to limit API usage.
+                    if (sets.Count == 0 && response.Cursor != null && notDownloadedRetries < 5)
+                    {
+                        notDownloadedRetries++;
+                        lastResponse = response;
+                        getSetsRequest = null;
+                        performRequest();
+                        return;
+                    }
+                }
 
-        // --- Sort ---
-        bool descending = sortDirection == SortDirection.Descending;
-        apiSets = sortCriteria switch
-        {
-            SortCriteria.Title => descending
-            ? apiSets.OrderByDescending(s => s.Title).ToList()
-            : apiSets.OrderBy(s => s.Title).ToList(),
-                  SortCriteria.Artist => descending
-                  ? apiSets.OrderByDescending(s => s.Artist).ToList()
-                  : apiSets.OrderBy(s => s.Artist).ToList(),
-                  SortCriteria.Difficulty => descending
-                  ? apiSets.OrderByDescending(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList()
-                  : apiSets.OrderBy(s => s.Beatmaps.Any() ? s.Beatmaps.Max(b => (double?)b.StarRating) ?? 0 : 0).ToList(),
-                  SortCriteria.Updated => descending
-                  ? apiSets.OrderByDescending(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList()
-                  : apiSets.OrderBy(s => s.LastUpdated ?? DateTimeOffset.MinValue).ToList(),
-                  _ => apiSets.OrderByDescending(s => s.Ranked).ToList(),
-        };
+                notDownloadedRetries = 0;
 
-        noMoreResults = true;
+                if (response.Cursor == null)
+                    noMoreResults = true;
 
-        if (apiSets.Count > 0)
-            searchControl.BeatmapSet = apiSets.First();
+                if (CurrentPage == 0)
+                    searchControl.BeatmapSet = sets.FirstOrDefault();
 
-        var resultsReturned = SearchResult.ResultsReturned(apiSets);
-        SearchFinished?.Invoke(resultsReturned);
-    });
-}
-
-private void performRequest()
-{
-    // "Downloaded" filter: use local database only, no API calls needed.
-    if (searchControl.Downloaded.Value == SearchDownloaded.Downloaded)
-    {
-        performLocalSearch();
-        return;
-    }
-
-    var downloadedIds = downloadedBeatmapSetIds;
-
-    getSetsRequest = new SearchBeatmapSetsRequest(
-        searchControl.Query.Value,
-        searchControl.Ruleset.Value,
-        lastResponse?.Cursor,
-        searchControl.General,
-        searchControl.Category.Value,
-        sortControl.Current.Value,
-        sortControl.SortDirection.Value,
-        searchControl.Genre.Value,
-        searchControl.Language.Value,
-        searchControl.Extra,
-        searchControl.Ranks,
-        searchControl.Played.Value,
-        searchControl.ExplicitContent.Value);
-
-    getSetsRequest.Success += response =>
-    {
-        var sets = response.BeatmapSets.ToList();
-
-        // Client-side filter: Not Downloaded
-        if (searchControl.Downloaded.Value == SearchDownloaded.NotDownloaded)
-        {
-            sets = sets.Where(s => !downloadedIds.Contains(s.OnlineID)).ToList();
-
-            // Auto-fetch more pages if this page was too sparse
-            bool shouldFetchMore = sets.Count < 10
-            && response.Cursor != null
-            && autoFetchDepth < 15;
-
-            if (shouldFetchMore)
-            {
-                autoFetchDepth++;
                 lastResponse = response;
                 getSetsRequest = null;
 
-                accumulatedSets.AddRange(sets);
+                if (!api.LocalUser.Value.IsSupporter)
+                {
+                    List<LocalisableString> filters = new List<LocalisableString>();
 
-                performRequest();
-                return;
-            }
+                    if (searchControl.Played.Value != SearchPlayed.Any)
+                        filters.Add(BeatmapsStrings.ListingSearchFiltersPlayed);
 
-            if (accumulatedSets.Count > 0)
-            {
-                accumulatedSets.AddRange(sets);
-                sets = accumulatedSets;
-                accumulatedSets = new List<APIBeatmapSet>();
-            }
+                    if (searchControl.Ranks.Any())
+                        filters.Add(BeatmapsStrings.ListingSearchFiltersRank);
+
+                    if (filters.Any())
+                    {
+                        var supporterOnlyFilters = SearchResult.SupporterOnlyFilters(filters);
+                        SearchFinished?.Invoke(supporterOnlyFilters);
+                        return;
+                    }
+                }
+
+                var resultsReturned = SearchResult.ResultsReturned(sets);
+                SearchFinished?.Invoke(resultsReturned);
+            };
+
+            api.Queue(getSetsRequest);
         }
 
-        autoFetchDepth = 0;
-        accumulatedSets.Clear();
-
-        if (sets.Count == 0 || response.Cursor == null)
-            noMoreResults = true;
-
-        if (CurrentPage == 0)
-            searchControl.BeatmapSet = sets.FirstOrDefault();
-
-        lastResponse = response;
-        getSetsRequest = null;
-
-        if (!api.LocalUser.Value.IsSupporter)
+        private void resetSearch()
         {
-            List<LocalisableString> filters = new List<LocalisableString>();
+            noMoreResults = false;
+            CurrentPage = 0;
 
-            if (searchControl.Played.Value != SearchPlayed.Any)
-                filters.Add(BeatmapsStrings.ListingSearchFiltersPlayed);
+            lastResponse = null;
 
-            if (searchControl.Ranks.Any())
-                filters.Add(BeatmapsStrings.ListingSearchFiltersRank);
+            getSetsRequest?.Cancel();
+            getSetsRequest = null;
 
-            if (filters.Any())
-            {
-                var supporterOnlyFilters = SearchResult.SupporterOnlyFilters(filters);
-                SearchFinished?.Invoke(supporterOnlyFilters);
-                return;
-            }
+            queryChangedDebounce?.Cancel();
+
+            notDownloadedRetries = 0;
         }
 
-        var resultsReturned = SearchResult.ResultsReturned(sets);
-        SearchFinished?.Invoke(resultsReturned);
-    };
+        protected override void Dispose(bool isDisposing)
+        {
+            resetSearch();
 
-    api.Queue(getSetsRequest);
-}
+            base.Dispose(isDisposing);
+        }
 
-private void resetSearch()
-{
-    noMoreResults = false;
-    CurrentPage = 0;
+        /// <summary>
+        /// Indicates the type of result of a user-requested beatmap search.
+        /// </summary>
+        public enum SearchResultType
+        {
+            /// <summary>
+            /// Actual results have been returned from API.
+            /// </summary>
+            ResultsReturned,
 
-    lastResponse = null;
+            /// <summary>
+            /// The user is not a supporter, but used supporter-only search filters.
+            /// </summary>
+            SupporterOnlyFilters
+        }
 
-    getSetsRequest?.Cancel();
-    getSetsRequest = null;
+        /// <summary>
+        /// Describes the result of a user-requested beatmap search.
+        /// </summary>
+        public struct SearchResult
+        {
+            public SearchResultType Type { get; private set; }
 
-    queryChangedDebounce?.Cancel();
+            /// <summary>
+            /// Contains the beatmap sets returned from API.
+            /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.ResultsReturned"/>.
+            /// </summary>
+            public List<APIBeatmapSet> Results { get; private set; }
 
-    autoFetchDepth = 0;
-    accumulatedSets.Clear();
-}
+            /// <summary>
+            /// Contains the names of supporter-only filters requested by the user.
+            /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.SupporterOnlyFilters"/>.
+            /// </summary>
+            public List<LocalisableString> SupporterOnlyFiltersUsed { get; private set; }
 
-protected override void Dispose(bool isDisposing)
-{
-    resetSearch();
+            public static SearchResult ResultsReturned(List<APIBeatmapSet> results) => new SearchResult
+            {
+                Type = SearchResultType.ResultsReturned,
+                Results = results,
+            };
 
-    base.Dispose(isDisposing);
-}
-
-/// <summary>
-/// Indicates the type of result of a user-requested beatmap search.
-/// </summary>
-public enum SearchResultType
-{
-    /// <summary>
-    /// Actual results have been returned from API.
-    /// </summary>
-    ResultsReturned,
-
-    /// <summary>
-    /// The user is not a supporter, but used supporter-only search filters.
-    /// </summary>
-    SupporterOnlyFilters
-}
-
-/// <summary>
-/// Describes the result of a user-requested beatmap search.
-/// </summary>
-public struct SearchResult
-{
-    public SearchResultType Type { get; private set; }
-
-    /// <summary>
-    /// Contains the beatmap sets returned from API.
-    /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.ResultsReturned"/>.
-    /// </summary>
-    public List<APIBeatmapSet> Results { get; private set; }
-
-    /// <summary>
-    /// Contains the names of supporter-only filters requested by the user.
-    /// Valid for read if and only if <see cref="Type"/> is <see cref="SearchResultType.SupporterOnlyFilters"/>.
-    /// </summary>
-    public List<LocalisableString> SupporterOnlyFiltersUsed { get; private set; }
-
-    public static SearchResult ResultsReturned(List<APIBeatmapSet> results) => new SearchResult
-    {
-        Type = SearchResultType.ResultsReturned,
-        Results = results,
-    };
-
-    public static SearchResult SupporterOnlyFilters(List<LocalisableString> filters) => new SearchResult
-    {
-        Type = SearchResultType.SupporterOnlyFilters,
-        SupporterOnlyFiltersUsed = filters
-    };
-}
-}
+            public static SearchResult SupporterOnlyFilters(List<LocalisableString> filters) => new SearchResult
+            {
+                Type = SearchResultType.SupporterOnlyFilters,
+                SupporterOnlyFiltersUsed = filters
+            };
+        }
+    }
 }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public Bindable<SearchPlayed> Played => playedFilter.Current;
 
+        public Bindable<SearchDownloaded> Downloaded => downloadedFilter.Current;
+
         public Bindable<SearchExplicit> ExplicitContent => explicitContentFilter.Current;
 
         public APIBeatmapSet? BeatmapSet
@@ -73,6 +75,7 @@ namespace osu.Game.Overlays.BeatmapListing
         private readonly BeatmapSearchMultipleSelectionFilterRow<SearchExtra> extraFilter;
         private readonly BeatmapSearchScoreFilterRow ranksFilter;
         private readonly BeatmapSearchFilterRow<SearchPlayed> playedFilter;
+        private readonly BeatmapSearchFilterRow<SearchDownloaded> downloadedFilter;
         private readonly BeatmapSearchFilterRow<SearchExplicit> explicitContentFilter;
 
         private readonly Box background;
@@ -137,6 +140,7 @@ namespace osu.Game.Overlays.BeatmapListing
                                     extraFilter = new BeatmapSearchMultipleSelectionFilterRow<SearchExtra>(BeatmapsStrings.ListingSearchFiltersExtra),
                                     ranksFilter = new BeatmapSearchScoreFilterRow(),
                                     playedFilter = new BeatmapSearchFilterRow<SearchPlayed>(BeatmapsStrings.ListingSearchFiltersPlayed),
+                                    downloadedFilter = new BeatmapSearchFilterRow<SearchDownloaded>("Downloaded"),
                                     explicitContentFilter = new BeatmapSearchFilterRow<SearchExplicit>(BeatmapsStrings.ListingSearchFiltersNsfw),
                                 }
                             }

--- a/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
+++ b/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd . Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public enum SearchDownloaded
+    {
+        Any,
+        Downloaded,
+        NotDownloaded
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
+++ b/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd . Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 namespace osu.Game.Overlays.BeatmapListing

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays
         private BeatmapListingFilterControl filterControl => Header.FilterControl;
 
         public BeatmapListingOverlay()
-        : base(OverlayColourScheme.Blue)
+            : base(OverlayColourScheme.Blue)
         {
         }
 
@@ -287,23 +287,23 @@ namespace osu.Game.Overlays
                     AutoSizeAxes = Axes.X,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(10, 0),
-                            Children = new Drawable[]
-                            {
-                                new Sprite
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    RelativeSizeAxes = Axes.Both,
-                                    FillMode = FillMode.Fit,
-                                    Texture = textures.Get(@"Online/not-found")
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Text = BeatmapsStrings.ListingSearchNotFoundQuote,
-                                }
-                            }
+                    Children = new Drawable[]
+                    {
+                        new Sprite
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            FillMode = FillMode.Fit,
+                            Texture = textures.Get(@"Online/not-found")
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = BeatmapsStrings.ListingSearchNotFoundQuote,
+                        }
+                    }
                 });
             }
         }
@@ -357,11 +357,11 @@ namespace osu.Game.Overlays
 
                 supporterRequiredText.AddText(
                     BeatmapsStrings.ListingSearchSupporterFilterQuoteDefault(string.Join(" and ", filtersUsed), "").ToString(),
-                                              t =>
-                                              {
-                                                  t.Font = OsuFont.GetFont(size: 16);
-                                                  t.Colour = Colour4.White;
-                                              }
+                    t =>
+                    {
+                        t.Font = OsuFont.GetFont(size: 16);
+                        t.Colour = Colour4.White;
+                    }
                 );
 
                 supporterRequiredText.AddLink(BeatmapsStrings.ListingSearchSupporterFilterQuoteLinkText.ToString(), @"/store/products/supporter-tag");
@@ -379,8 +379,8 @@ namespace osu.Game.Overlays
             const int pagination_scroll_distance = 500;
 
             bool shouldShowMore = panelLoadTask?.IsCompleted != false
-            && Time.Current - lastFetchDisplayedTime > time_between_fetches
-            && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
+                                  && Time.Current - lastFetchDisplayedTime > time_between_fetches
+                                  && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
 
             if (shouldShowMore)
                 filterControl.FetchNextPage();

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays
         private BeatmapListingFilterControl filterControl => Header.FilterControl;
 
         public BeatmapListingOverlay()
-            : base(OverlayColourScheme.Blue)
+        : base(OverlayColourScheme.Blue)
         {
         }
 
@@ -167,9 +167,18 @@ namespace osu.Game.Overlays
 
             if (filterControl.CurrentPage == 0)
             {
-                //No matches case
+                //No matches case — but only dead-end if the API is truly exhausted
                 if (!newCards.Any())
                 {
+                    // If the API still has more pages, fetch the next one instead
+                    // of showing the NotFoundDrawable dead-end. This keeps the
+                    // scrollable content alive so the auto-fetch in Update()
+                    // can continue paginating.
+                    if (filterControl.HasMorePages)
+                    {
+                        filterControl.FetchNextPage();
+                        return;
+                    }
                     replaceResultsAreaContent(new NotFoundDrawable());
                     return;
                 }
@@ -278,23 +287,23 @@ namespace osu.Game.Overlays
                     AutoSizeAxes = Axes.X,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(10, 0),
-                    Children = new Drawable[]
-                    {
-                        new Sprite
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both,
-                            FillMode = FillMode.Fit,
-                            Texture = textures.Get(@"Online/not-found")
-                        },
-                        new OsuSpriteText
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Text = BeatmapsStrings.ListingSearchNotFoundQuote,
-                        }
-                    }
+                            Children = new Drawable[]
+                            {
+                                new Sprite
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    RelativeSizeAxes = Axes.Both,
+                                    FillMode = FillMode.Fit,
+                                    Texture = textures.Get(@"Online/not-found")
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Text = BeatmapsStrings.ListingSearchNotFoundQuote,
+                                }
+                            }
                 });
             }
         }
@@ -348,11 +357,11 @@ namespace osu.Game.Overlays
 
                 supporterRequiredText.AddText(
                     BeatmapsStrings.ListingSearchSupporterFilterQuoteDefault(string.Join(" and ", filtersUsed), "").ToString(),
-                    t =>
-                    {
-                        t.Font = OsuFont.GetFont(size: 16);
-                        t.Colour = Colour4.White;
-                    }
+                                              t =>
+                                              {
+                                                  t.Font = OsuFont.GetFont(size: 16);
+                                                  t.Colour = Colour4.White;
+                                              }
                 );
 
                 supporterRequiredText.AddLink(BeatmapsStrings.ListingSearchSupporterFilterQuoteLinkText.ToString(), @"/store/products/supporter-tag");
@@ -370,8 +379,8 @@ namespace osu.Game.Overlays
             const int pagination_scroll_distance = 500;
 
             bool shouldShowMore = panelLoadTask?.IsCompleted != false
-                                  && Time.Current - lastFetchDisplayedTime > time_between_fetches
-                                  && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
+            && Time.Current - lastFetchDisplayedTime > time_between_fetches
+            && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
 
             if (shouldShowMore)
                 filterControl.FetchNextPage();


### PR DESCRIPTION
## Summary

Adds "Downloaded" and "Not Downloaded" filters to the beatmap listing search interface, allowing users to filter beatmap search results by whether they already have the beatmap set downloaded locally.

## Screenshots

<img width="2179" height="1292" alt="image" src="https://github.com/user-attachments/assets/23a8475c-09c9-4c5a-84de-c248393380cf" />
<img width="2174" height="1373" alt="image" src="https://github.com/user-attachments/assets/71f619d0-87ab-4869-8510-ba2e925c66fe" />

## Changes

### New file
- `osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs` — Enum with `Any`, `Downloaded`, `NotDownloaded` values, following the same pattern as `SearchPlayed`.

### Modified files

**`osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs`**
- Added a new `BeatmapSearchFilterRow<SearchDownloaded>` row labeled "Downloaded", exposed via `Downloaded` bindable property, placed between the existing "Played" and "Explicit Content" filter rows.

**`osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs`**
- Changed `RealmAccess` injection from `[Resolved]` to `[BackgroundDependencyLoader]` parameter to ensure reliable initialization.
- Added `downloadedBeatmapSetIds` field — a `HashSet<int>` of online IDs for all locally-downloaded beatmap sets, pre-populated on load.
- Added `performLocalSearch()` method that queries Realm for all non-deleted `BeatmapSetInfo` entries with valid online IDs, applies Status (Category), Ruleset, Played, and text search filters locally, converts results to `APIBeatmapSet` for the display layer, builds cover URLs via the standard `assets.ppy.sh` CDN pattern using `Newtonsoft.Json` deserialization, applies sorting locally (Title, Artist, Difficulty, Updated, Ranked), and fires `SearchFinished` with the complete result set.
- Added `buildCovers()` helper that constructs `BeatmapSetOnlineCovers` with correct CDN URLs from a beatmap's online ID using JSON deserialization to match the API response format.
- Modified `performRequest()`: when "Downloaded" is selected, routes to `performLocalSearch()` with zero API calls. When "Not Downloaded" is selected, uses the normal API path with client-side filtering and auto-fetches up to 16 pages to fill sparse results. When "Any" is selected, passes through to the API normally with no changes.
- Wired up `searchControl.Downloaded.BindValueChanged` in `LoadComplete()` to trigger searches on filter change.
- Added `resetSearch()` cleanup for auto-fetch tracking fields.

## Design decisions

### "Downloaded" = local Realm query, not API

Since downloaded maps are entirely local by definition, hitting the API for them would be both wasteful and unreliable (server pagination can't guarantee finding all local maps). The Realm query returns all matching maps instantly, with local filtering and sorting approximating what the server would do.

### Server-dependent filters unsupported locally

The following API filters have no local equivalent and are silently ignored when "Downloaded" is active: Genre, Language, Extra (Video/Storyboard), Ranks, Explicit Content, General filters (Recommended/Converts/Follows/Spotlights/Featured Artists). These filters rely on server-side data not stored in the local Realm database. Users can still use Status, Ruleset, Played, and text search filters which work on both local and API results.

### Cover images via JSON deserialization

`BeatmapSetOnlineCovers` uses `[JsonProperty]` attributes for its properties, and some may have internal or init-only setters. Rather than using reflection, we construct a JSON string matching the API response format and deserialize it — the same path the API responses take, guaranteeing compatibility regardless of property access modifiers.

### Thread safety

The `downloadedBeatmapSetIds` hashset is populated on the main thread during `LoadComplete`. In `performRequest()`, it's captured into a local variable before any async work begins, preventing race conditions if the user rapidly changes filters.

## Testing

- Tested on Linux (Bazzite/Fedora 42, .NET 10.0.100, RX 9070 XT GPU)
- "Downloaded" correctly shows 117 local beatmaps with cover images, all filters and sorting functional
- "Not Downloaded" correctly filters out local maps from API results with auto-fetch accumulation
- "Any" passes through to API normally with zero behavioral change
- Rapidly switching between filter tabs does not crash or produce stale results
- Filter resets correctly when changing other search criteria (text, status, ruleset, etc.)